### PR TITLE
Add package.json for publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "entypo",
+  "version": "2.0.0",
+  "description": "411 carefully crafted premium pictograms by Daniel Bruce",
+  "main": "font/demo.html",
+  "style": "font/entypo.css",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "make"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/danielbruce/entypo.git"
+  },
+  "keywords": [
+    "entypo",
+    "icons",
+    "css",
+    "svg",
+    "font"
+  ],
+  "author": "Daniel Bruce <me@danielbruce.se> (http://www.danielbruce.se)",
+  "license": "SIL",
+  "bugs": {
+    "url": "https://github.com/danielbruce/entypo/issues"
+  },
+  "homepage": "http://www.entypo.com"
+}


### PR DESCRIPTION
Hi Daniel,

Awesome work! I've made this pull request to make it easier for people using node.js module loading system to overload css `@import` statements. It makes it a lot easier to manage dependencies such as icons fonts in ones projects. Eg.

``` css
@import 'entypo';

.view-details {
  font-family: 'entypo';
  //...
}
```

I've prepared the `package.json` file for you, and all you need to do is to publish it to the npm registry: https://www.youtube.com/watch?v=BkotrAFtBM0
